### PR TITLE
Get GEXF generator public URL from server config rather than hard-coding

### DIFF
--- a/components/SNA/TwitterSna/Hooks/call-elastic.js
+++ b/components/SNA/TwitterSna/Hooks/call-elastic.js
@@ -676,7 +676,7 @@ function buildQueryMultipleMatchPhrase (field, arr) {
                     let gexfRes = {};
                     gexfRes.title = message.title
                     gexfRes.fileName = message.fileName;
-                    gexfRes.getUrl = `https://weverify-gexf.gate.ac.uk/generate/downloadGEXF?fileName=${message.fileName}`; //${gexfGen_url}
+                    gexfRes.getUrl = `${publicRuntimeConfig.gexfBase}downloadGEXF?fileName=${message.fileName}`; //${gexfGen_url}
                     gexfRes.visualizationUrl = `https://mever.iti.gr/networkx/plugin?filepath=${gexfRes.getUrl}`;
                     gexfRes.message = message.message
                     gexfResults.push(gexfRes)

--- a/next.config.js
+++ b/next.config.js
@@ -20,7 +20,7 @@ module.exports = {
   publicRuntimeConfig: {
     baseFolder: getBasePath(),
     gakey: process.env.REACT_APP_GOOGLE_ANALYTICS_KEY,
-
+    gexfBase: process.env.REACT_APP_GEXF_GENERATOR_URL,
   },
   webpack: (config) => {
     config.output.globalObject = `(typeof self !== 'undefined' ? self : this)`;


### PR DESCRIPTION
The base URL for the GEXF generator is supplied via an environment variable on the server, so pass that through to client side via `publicRuntimeConfig` instead of hard-coding the production location in the JS.